### PR TITLE
Added supplemental libraries to allow for saving exported image

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,34 +1,58 @@
-import React from 'react';
-import { View, Button } from 'react-native';
-import * as FileSystem from 'expo-file-system';
+import React, { useRef, useEffect, useState } from 'react';
+import { View, Button, Alert } from 'react-native';
 import { captureRef } from 'react-native-view-shot';
+import * as MediaLibrary from 'expo-media-library';
+import * as Permissions from 'expo-permissions'; // Import the Permissions module
 import Heart from './Heart';
 
 export default function App() {
+  const heartRef = useRef(null);
+  const [mediaLibraryPermission, setMediaLibraryPermission] = useState(null);
+
+  useEffect(() => {
+    // Check and request permissions when the component mounts
+    async function checkMediaLibraryPermission() {
+      const { status } = await Permissions.askAsync(Permissions.MEDIA_LIBRARY);
+      setMediaLibraryPermission(status === 'granted');
+    }
+
+    checkMediaLibraryPermission();
+  }, []);
+
   const handleScreenshot = async () => {
     try {
+      if (!mediaLibraryPermission) {
+        Alert.alert(
+          'Permission Required',
+          'Please grant access to the media library to save the screenshot.'
+        );
+        return;
+      }
+
+      if (!heartRef.current) {
+        return;
+      }
+
       // Capture the Heart component as an image
-      const uri = await captureRef(this.heartRef, {
+      const uri = await captureRef(heartRef, {
         format: 'png',
         quality: 1,
       });
 
-      // Save the captured image to the device's file system
-      const filename = `${FileSystem.cacheDirectory}heart_screenshot.png`;
-      await FileSystem.moveAsync({
-        from: uri,
-        to: filename,
-      });
+      // Save the captured image to the device's media library (camera roll)
+      const asset = await MediaLibrary.createAssetAsync(uri);
+      await MediaLibrary.createAlbumAsync('HeartScreenshots', asset, false);
 
-      console.log(`Screenshot saved at: ${filename}`);
+      console.log(`Screenshot saved in the camera roll`);
+      Alert.alert('Screenshot Saved', 'The screenshot has been saved to your camera roll.');
     } catch (error) {
-      console.error('Error capturing screenshot:', error);
+      console.error('Error capturing or saving screenshot:', error);
     }
   };
 
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <View ref={(view) => (this.heartRef = view)}>
+      <View ref={heartRef}>
         <Heart />
       </View>
       <Button title="Take Screenshot" onPress={handleScreenshot} />

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # svg-export-module
+
+## Functionality
+
+The purpose of this repository is to act as a sandbox in creating a React Native module that can interact with and successfully export SVG files. 
+
+## Drawbacks
+
+The modules built in to React Native View Shot would require us to select specific file formats to save the ```<View/>``` to.
+
+## Notes
+
+- expo media library package to save to camera roll. Not sure if this option would be successful in tandem or as an aside to using React Native's camera-roll package.
+
+This application requires the following dependencies: 
+
+ [React Native SVG](https://www.npmjs.com/package/react-native-svg)
+  - ```expo install react-native-svg``` 
+  
+
+  [React Native View-Shot](https://www.npmjs.com/package/react-native-view-shot)
+  - ```expo install react-native-view-shot``` 
+  
+  [Expo Media Library](https://docs.expo.dev/versions/latest/sdk/media-library/)
+  - ```npx expo install expo-media-library```
+
+  [Expo Permissions](https://docs.expo.dev/guides/permissions/)
+  - ```expo install expo-permissions```

--- a/app.json
+++ b/app.json
@@ -1,5 +1,15 @@
 {
   "expo": {
+    "plugins": [
+      [
+        "expo-media-library",
+        {
+          "photosPermission": "Allow StencilShaper to access your photos.",
+          "savePhotosPermission": "Allow StencilShaper to save photos.",
+          "isAccessMediaLocationEnabled": true
+        }
+      ]
+    ],
     "name": "svg-export-module",
     "slug": "svg-export-module",
     "version": "1.0.0",

--- a/components/Heart.js
+++ b/components/Heart.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View } from 'react-native';
 import { Svg, Path } from 'react-native-svg';
 
-const TestView = () => {
+const Heart = () => {
   return (
     <View>
       <Svg width="100" height="100" viewBox="0 0 24 24">
@@ -15,4 +15,4 @@ const TestView = () => {
   );
 };
 
-export default TestView;
+export default Heart;

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -7612,6 +7612,14 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-media-library": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-15.4.1.tgz",
+      "integrity": "sha512-lpWcT4pynWcE7TyNMUkLFH4YcueCTnq7UOJYRR0vewPEJeQXwRscka7zBtrhA+RSsJda013Q0615K+5lRLt14Q==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.5.1.tgz",
@@ -7732,6 +7740,14 @@
       "dependencies": {
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-permissions": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/expo-permissions/-/expo-permissions-14.2.1.tgz",
+      "integrity": "sha512-jXGnOODtDMFvK7cwo7wIRPcnA7m1bie80gJ5BdL6Vs5kgCU7+RCLOCp3sBw7TKRPIlVMmQDhZA62bGzoBV0hkA==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "expo": "~49.0.10",
         "expo-file-system": "^15.6.0",
+        "expo-media-library": "~15.4.1",
+        "expo-permissions": "~14.2.1",
         "expo-status-bar": "~1.6.0",
         "react": "18.2.0",
         "react-native": "0.72.4",
@@ -7628,6 +7630,14 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-media-library": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-15.4.1.tgz",
+      "integrity": "sha512-lpWcT4pynWcE7TyNMUkLFH4YcueCTnq7UOJYRR0vewPEJeQXwRscka7zBtrhA+RSsJda013Q0615K+5lRLt14Q==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.5.1.tgz",
@@ -7748,6 +7758,14 @@
       "dependencies": {
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-permissions": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/expo-permissions/-/expo-permissions-14.2.1.tgz",
+      "integrity": "sha512-jXGnOODtDMFvK7cwo7wIRPcnA7m1bie80gJ5BdL6Vs5kgCU7+RCLOCp3sBw7TKRPIlVMmQDhZA62bGzoBV0hkA==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "react": "18.2.0",
     "react-native": "0.72.4",
     "react-native-svg": "^13.13.0",
-    "react-native-view-shot": "^3.7.0"
+    "react-native-view-shot": "^3.7.0",
+    "expo-media-library": "~15.4.1",
+    "expo-permissions": "~14.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
- The previous commit message had handling for utilizing the Expo media library package, but did not have permissions configured. 
- This branch integrates permission handling for both iOS and Android.